### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+- "8"
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+install:
+  - npm install
+  - cd UI
+  - npm install
+  - cd ..
+script:
+  - npm run test
+  - cd UI
+  - npm run test
+  - cd ..

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## JS18_ProjectA_Group2
 
-**Open a terminal** on **root** folder. 
+[![Build Status](https://travis-ci.org/Rostlab/JS18_ProjectA_Group2.svg?branch=develop)](https://travis-ci.org/Rostlab/JS18_ProjectA_Group2)
+
+**Open a terminal** on **root** folder.
 Run below command to install all the dependency mentioned in server package.json.
   >npm install
 
@@ -11,17 +13,12 @@ It will generate covarage report. You can check how good your unit testing cover
 Run below command to start the server. The backend.
   >npm start
 
-**Open another terminal** at **UI folder** inside root. 
+**Open another terminal** at **UI folder** inside root.
 Run below command to install all UI dependency from its package.json.
   >npm install
 
 To test UI app. Use below command.
   >npm test
 
-To start the angular server, use below command which internally runs `"ng serve"`. It builds the application and start it. It will open in watch mode to keep checking changes you do and build simontaneously. 
+To start the angular server, use below command which internally runs `"ng serve"`. It builds the application and start it. It will open in watch mode to keep checking changes you do and build simontaneously.
   >npm start
-
-
-
-
-

--- a/UI/karma.conf.js
+++ b/UI/karma.conf.js
@@ -2,7 +2,7 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = function (config) {
-  config.set({
+  var configuration = {
     basePath: '',
     frameworks: ['jasmine', '@angular/cli'],
     plugins: [
@@ -28,6 +28,18 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
     singleRun: true
-  });
+  };
+
+  if (process.env.TRAVIS) {
+    configuration.browsers = ['Chrome_travis_ci'];
+  }
+
+  config.set(configuration);
 };


### PR DESCRIPTION
- Run with Node.js 8.x
- Configure Chrome for Karma
- Add travis badge on README

Also I had to tweak your `karma.conf.js` in order to fix this error during a karma run:
```
Chrome stderr: [3683:3683:0308/170617.183524:FATAL:setuid_sandbox_host.cc(157)]
The SUID sandbox helper binary was found, but is not configured correctly.
Rather than run without sandboxing I'm aborting now.
You need to make sure that /usr/lib/chromium-browser/chrome-sandbox
is owned by root and has mode 4755.
```